### PR TITLE
Added beep method

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ module.exports = {
   log: require('./lib/log'),
   template: require('./lib/template'),
   env: require('optimist').argv,
-  File: require('./lib/File')
+  File: require('./lib/File'),
+  beep: require('./lib/beep')
 };

--- a/lib/beep.js
+++ b/lib/beep.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  process.stdout.write('\x07');
+};

--- a/test/main.js
+++ b/test/main.js
@@ -171,4 +171,23 @@ describe('gulp-util', function() {
     });
   });
 
+  describe('beep()', function(){
+    it('should send the right code to stdout', function(done){
+      var writtenValue;
+
+      // Stub process.stdout.write
+      var stdout_write = process.stdout.write;
+      process.stdout.write = function(value) {
+        writtenValue = value;
+      };
+
+      util.beep();
+      writtenValue.should.equal('\x07');
+
+      // Restore process.stdout.write
+      process.stdout.write = stdout_write
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Tasks may wish to send an alert to the terminal. This is especially useful to indicate test failure with an audible/visual indicator.

In the future, we may want to silence beeps with log levels or options, so I've added a test that stubs out `process.stdout.write` so we have a pattern to follow when we want to test silent mode.
