### PR TITLE
Added extend method

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ module.exports = {
   template: require('./lib/template'),
   env: require('optimist').argv,
   File: require('./lib/File'),
-  beep: require('./lib/beep')
+  beep: require('./lib/beep'),
+  extend: require('./lib/extend')
 };

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -1,0 +1,10 @@
+module.exports = function(dest) {
+	var i, prop, source;
+	for (i = 1; i < arguments.length; i++) {
+		source = arguments[i];
+		for (prop in source) {
+			dest[prop] = source[prop];
+		}
+	}
+	return dest;
+};

--- a/test/main.js
+++ b/test/main.js
@@ -190,4 +190,29 @@ describe('gulp-util', function() {
     });
   });
 
+  describe('extend()', function() {
+    it('should overwrite properties in the right order', function(done) {
+      var obj = util.extend({ x: 1 }, { x: 2 }, { x: 3});
+      obj.x.should.equal(3);
+      done();
+    });
+
+    it('should combine objects', function(done) {
+      var obj = util.extend({ x: 1 }, { y: 2 }, { z: 3});
+      obj.x.should.equal(1);
+      obj.y.should.equal(2);
+      obj.z.should.equal(3);
+      done();
+    });
+
+    it('should not error when passed undefined or null', function(done) {
+      (function() {
+        var obj = util.extend({ x: 1 }, undefined, { y: 2 }, null, undefined, {});
+
+        obj.x.should.equal(1);
+        obj.y.should.equal(2);
+      }).should.not.throw();
+      done();
+    });
+  });
 });


### PR DESCRIPTION
As many Gulp tasks will accept options, it becomes necessary to have a mechanism for setting default options.

`extend` can be used to do this. For instance, the following code could conceivably appear in a Gulp plugin:

```
if (!opt) opt = {};
opt.trueByDefault = typeof opt.trueByDefault !== 'undefined' : opt.trueByDefault : true;
opt.falseByDefault = opt.someOption || false;
opt.someOption = opt.someOption || 'someOption';
```

This could be changed to:

```
opt = gutil.extend({
  falseByDefault: false,
  trueByDefault: true,
  someOption: 'someOption'
}, opt);
```

Passed options will override defaults, and, in the case that `opt` is undefined, `extend` will give the defaults.
