### PR TITLE
use lodash._reinterpolate to have ES6 delimiters, add more template tests

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -1,9 +1,10 @@
 var template = require('lodash.template');
+var reInterpolate = require('lodash._reinterpolate');
 
 var forcedSettings = {
   escape: /<%-([\s\S]+?)%>/g,
   evaluate: /<%([\s\S]+?)%>/g,
-  interpolate: /<%=([\s\S]+?)%>/g
+  interpolate: reInterpolate
 };
 
 module.exports = function(tmpl, data){

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
   "dependencies": {
     "chalk": "~0.3.0",
     "lodash.template": "~2.4.1",
+    "lodash._reinterpolate": "~2.4.1",
     "optimist": "~0.6.0"
   },
   "devDependencies": {
     "mocha": "*",
     "should": "*",
-    "event-stream": "*"
+    "event-stream": "*",
+    "lodash.templatesettings": "~2.4.1"
   },
   "scripts": {
     "test": "mocha"

--- a/test/main.js
+++ b/test/main.js
@@ -51,6 +51,7 @@ describe('gulp-util', function() {
       etmpl.should.equal(expected);
       done();
     });
+
     it('should work with a template and data', function(done){
       var opt = {
         name:"todd",
@@ -76,6 +77,51 @@ describe('gulp-util', function() {
         should.exist(err);
         done();
       }
+    });
+
+    it('should ignore modified templateSettings', function(done){
+      var templateSettings = require('lodash.templatesettings');
+      templateSettings.interpolate = /\{\{([\s\S]+?)\}\}/g;
+
+      var opt = {
+        name:"todd",
+        file: {
+          path: "hi.js"
+        }
+      };
+      var expected = "test {{name}} hi.js";
+
+      var tmpl = util.template('test {{name}} <%= file.path %>');
+      should.exist(tmpl);
+      'function'.should.equal(typeof(tmpl));
+
+      // eval it now
+      var etmpl = tmpl(opt);
+      'string'.should.equal(typeof(etmpl));
+      etmpl.should.equal(expected);
+
+      done();
+    });
+
+    it('should allow ES6 delimiters', function(done){
+      var opt = {
+        name:"todd",
+        file: {
+          path: "hi.js"
+        }
+      };
+      var expected = "test todd hi.js";
+
+      var tmpl = util.template('test ${name} ${file.path}');
+      should.exist(tmpl);
+      'function'.should.equal(typeof(tmpl));
+
+      // eval it now
+      var etmpl = tmpl(opt);
+      'string'.should.equal(typeof(etmpl));
+      etmpl.should.equal(expected);
+
+      done();
     });
 
   });


### PR DESCRIPTION
`lodash.template` compares the interpolate instance to `lodash._reinterpolate` to know if it should allow ES6 delimiters.  By using it as the force value, we can still have ES6 delimiters and force default settings in `gutil.template`.

@jdalton said `escape` and `evaluate` defaults will be exposed as modules on next release.
