### PR TITLE
Use multipipe in place of stream-combiner

### DIFF
--- a/lib/combine.js
+++ b/lib/combine.js
@@ -1,4 +1,4 @@
-var pipeline = require('stream-combiner');
+var pipeline = require('multipipe');
 
 module.exports = function(){
   var args = arguments;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "vinyl": "~0.2.1",
     "through": "~2.3.4",
     "dateformat": "~1.0.7-1.2.3",
-    "stream-combiner": "0.0.4"
+    "multipipe": "0.0.1"
   },
   "devDependencies": {
     "mocha": "~1.17.0",


### PR DESCRIPTION
Re: gulpjs/gulp#157

Both modules offer the same API and purpose, however the former is
implemented using the newer stream API.

Cheers!
