### PR TITLE
Fixed buffer bug from through2 upgrade

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -1,11 +1,11 @@
 var through = require('through2');
 
-module.exports = function(cb) {
+module.exports = function(fn) {
   var buf = [];
-  var end = function() {
-    this.emit('data', buf);
-    this.emit('end');
-    if(cb) cb(null, buf);
+  var end = function(cb) {
+    this.push(buf);
+    cb();
+    if(fn) fn(null, buf);
   };
   var push = function(data, enc, cb) {
     buf.push(data);

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -24,4 +24,13 @@ describe('buffer()', function(){
       done();
     });
   });
+  it('should buffer stuff and return a stream with the buffered data', function(done){
+    var src = [1,2,3];
+    var inp = es.readArray(src);
+    inp.pipe(util.buffer()).pipe(es.through(function(data) {
+      should.exist(data);
+      data.should.eql(src);
+      done();
+    }));
+  });
 });


### PR DESCRIPTION
Emitting `data` with `through2` doesn't actually pass the data to the next stream. You have to `push` it since these are `Steams2`. This fix passes the buffered data in the next stream. The test I added would've passed before the `through` to `through2` upgrade.
