### PR TITLE
Added a timestamp to `.log()`

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,8 +1,11 @@
 var colors = require('./colors');
+var date = require('./date');
 
 module.exports = function(){
   var sig = '['+colors.green('gulp')+']';
+  var time = '['+colors.grey(date(new Date(), "hh:MM:ssTT"))+']';
   var args = Array.prototype.slice.call(arguments);
+  args.unshift(time);
   args.unshift(sig);
   console.log.apply(console, args);
   return this;

--- a/test/log.js
+++ b/test/log.js
@@ -14,7 +14,8 @@ describe('log()', function(){
     };
 
     util.log(1, 2, 3, 4, 'five');
-    writtenValue.should.eql('['+util.colors.green('gulp')+'] 1 2 3 4 five\n');
+    var time = util.date(new Date(), "hh:MM:ssTT");
+    writtenValue.should.eql('['+util.colors.green('gulp')+'] [' + util.colors.grey(time) + '] 1 2 3 4 five\n');
 
     // Restore process.stdout.write
     process.stdout.write = stdout_write;


### PR DESCRIPTION
The tests are not optimal since there might be a race condition where .log() generates another timestamp than the one that's generated for assertion.

Any thoughts on this?
