### PR TITLE
Remove unsupported node version from ".travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.9"
   - "0.10"
 after_script:
   - npm run coveralls


### PR DESCRIPTION
Travis CI never seems to have supported node 0.9.

Until recently, Travis CI silently ignored unsupported node versions and used the default version instead, as you can see in [this `gulp-util` build log (from April 5)](https://travis-ci.org/gulpjs/gulp-util/jobs/22359264).

These days, Travis CI will fail if unsupported node version is requested ([list of supported versions](http://docs.travis-ci.com/user/ci-environment/#Node.js-VM-images)). This pull request removes version `0.9` from `.travis.yml` to allow proper build success/error reporting.
