### PR TITLE
Fix hard-coded path separator in assertion string

### DIFF
--- a/test/File.js
+++ b/test/File.js
@@ -40,7 +40,7 @@ describe('File()', function() {
     file.path.should.equal(fname);
     file.cwd.should.equal(__dirname);
     file.base.should.equal(base);
-    file.relative.should.equal('fixtures/test.coffee');
+    file.relative.should.equal(path.join('fixtures', 'test.coffee'));
     done();
   });
 });


### PR DESCRIPTION
Fix a test that was failing on Windows because of hard-coded path separator in assertion string.
