### PR TITLE
Update "through2" and "minimist" to match the current version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "lodash.template": "^2.4.1",
     "lodash._reinterpolate": "^2.4.1",
     "vinyl": "^0.2.1",
-    "through2": "^0.4.0",
+    "through2": "^0.5.0",
     "dateformat": "^1.0.7-1.2.3",
     "multipipe": "^0.1.0",
-    "minimist": "^0.1.0"
+    "minimist": "^0.2.0"
   },
   "devDependencies": {
     "mocha": "^1.17.0",


### PR DESCRIPTION
Helps when [deduping](https://www.npmjs.org/doc/cli/npm-dedupe.html) projects using `gulp-util`.
