### PR TITLE
Expose option to override properties included on Plugin Error, copy all properties from original error by default

### DIFF
--- a/lib/PluginError.js
+++ b/lib/PluginError.js
@@ -1,5 +1,6 @@
 var util = require('util');
 var colors = require('./colors');
+var uniq = require('lodash.uniq');
 
 // wow what a clusterfuck
 var parseOptions = function(plugin, message, opt) {
@@ -9,6 +10,9 @@ var parseOptions = function(plugin, message, opt) {
   } else if (message instanceof Error) {
     opt.error = message;
     opt.plugin = plugin;
+    if (!opt.properties) {
+      opt.properties = Object.keys(message);
+    }
   } else if (typeof message === 'object') {
     opt = message;
     opt.plugin = plugin;
@@ -16,6 +20,15 @@ var parseOptions = function(plugin, message, opt) {
     opt.plugin = plugin;
     opt.message = message;
   }
+
+  var defaultProperties = ['name', 'message', 'fileName', 'lineNumber', 'stack'];
+
+  if (!opt.properties) {
+    opt.properties = [];
+  }
+
+  opt.properties = uniq(defaultProperties.concat(opt.properties));
+
   return opt;
 };
 
@@ -29,17 +42,15 @@ function PluginError(plugin, message, opt) {
   this.plugin = options.plugin;
   this.showStack = options.showStack === true;
 
-  var properties = ['name', 'message', 'fileName', 'lineNumber', 'stack'];
-
   // if options has an error, grab details from it
   if (options.error) {
-    properties.forEach(function(prop) {
+    options.properties.forEach(function(prop) {
       if (prop in options.error) this[prop] = options.error[prop];
     }, this);
   }
 
   // options object can override
-  properties.forEach(function(prop) {
+  options.properties.forEach(function(prop) {
     if (prop in options) this[prop] = options[prop];
   }, this);
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lodash._reinterpolate": "^2.4.1",
     "lodash.template": "^2.4.1",
     "minimist": "^0.2.0",
+    "lodash.uniq": "~2.4.1",
     "multipipe": "^0.1.0",
     "through2": "^0.5.0",
     "vinyl": "^0.2.1"

--- a/test/PluginError.js
+++ b/test/PluginError.js
@@ -69,4 +69,24 @@ describe('PluginError()', function(){
     done();
   });
 
+  it('should take properties from error by default', function() {
+    var realErr = new Error('something broke');
+    realErr.abstractProperty = 'abstract';
+    var err = new util.PluginError('test', realErr);
+    err.plugin.should.equal('test');
+    err.message.should.equal('something broke');
+    err.abstractProperty.should.equal('abstract');
+  });
+
+  it('should take properties from error unless overridden in options', function() {
+    var realErr = new Error('something broke');
+    realErr.abstractProperty = 'abstract';
+    realErr.notIncludedProperty = 'abstract';
+    var err = new util.PluginError('test', realErr, {properties: ['abstractProperty']});
+    err.plugin.should.equal('test');
+    err.message.should.equal('something broke');
+    err.abstractProperty.should.equal('abstract');
+    (err.notIncludedProperty === undefined).should.be.true;
+  });
+
 });


### PR DESCRIPTION
Currently when you create a PluginError with an existing error the properties of the original error are lost unless they are included on an internal list of white listed properties. I propose two enhancements:
1. Provide a means to override the white listed properties.
2. If no white list properties are provided, then include all properties from the original error.
