### PR TITLE
Add string formatting support to log

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -4,7 +4,9 @@ var date = require('./date');
 module.exports = function(){
   var time = '['+colors.grey(date(new Date(), 'HH:MM:ss'))+']';
   var args = Array.prototype.slice.call(arguments);
-  args.unshift(time);
+  var first = args.shift() || '';
+  first = time + ' ' + first;
+  args.unshift(first);
   console.log.apply(console, args);
   return this;
 };

--- a/test/log.js
+++ b/test/log.js
@@ -13,9 +13,9 @@ describe('log()', function(){
       writtenValue = value;
     };
 
-    util.log(1, 2, 3, 4, 'five');
+    util.log('%s + %s + %s =', 1, 2, 3, 'five');
     var time = util.date(new Date(), 'HH:MM:ss');
-    writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 2 3 4 five\n');
+    writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 + 2 + 3 = five\n');
 
     // Restore process.stdout.write
     process.stdout.write = stdout_write;


### PR DESCRIPTION
I see from #33 that this logger will be deprecated soon, but even so it was pretty trivial to add string formatting support since node’s `console.log` already pipes its input through `util.format`.

Ex:

``` javascript
log('%s + %s + %s =', 1, 2, 3, 'five');
// => [02:32:01] 1 + 2 + 3 = five
```
