### PR TITLE
use `beeper` module which checks TTY and adheres to `--no-beep` flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
   log: require('./lib/log'),
   template: require('./lib/template'),
   env: require('./lib/env'),
-  beep: require('./lib/beep'),
+  beep: require('beeper'),
   noop: require('./lib/noop'),
   isStream: require('./lib/isStream'),
   isBuffer: require('./lib/isBuffer'),

--- a/lib/beep.js
+++ b/lib/beep.js
@@ -1,3 +1,0 @@
-module.exports = function() {
-  process.stdout.write('\x07');
-};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "wearefractal/gulp-util",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "dependencies": {
+    "beeper": "^1.0.0",
     "chalk": "^0.5.1",
     "dateformat": "^1.0.7-1.2.3",
     "lodash": "^2.4.1",


### PR DESCRIPTION
This makes it easy to disable beep from the CLI and it won't output the control character when piped.

https://github.com/sindresorhus/beeper
## 

Sidenote: I really wish we could get rid of gulp-util soon...
