### PR TITLE
Allow for the PluginError constructor to be called without `new`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ var err = new gutil.PluginError('test', 'something broke', {showStack: true});
 
 var existingError = new Error('OMG');
 var err = new gutil.PluginError('test', existingError, {showStack: true});
+
+var err = gutil.PluginError('test', 'something broke');
 ```
 
 [npm-url]: https://www.npmjs.com/package/gulp-util

--- a/lib/PluginError.js
+++ b/lib/PluginError.js
@@ -30,7 +30,7 @@ var parseOptions = function(plugin, message, opt) {
 };
 
 function PluginError(plugin, message, opt) {
-  if (!(this instanceof PluginError)) throw new Error('Call PluginError using new');
+  if (!(this instanceof PluginError)) return new PluginError(plugin, message, opt);
 
   Error.call(this);
 

--- a/test/PluginError.js
+++ b/test/PluginError.js
@@ -189,4 +189,9 @@ describe('PluginError()', function(){
     var err = new util.PluginError('plugin', 'message');
     err.toString().indexOf('Details:').should.equal(-1);
   });
+  
+  it('should work without new', function () {
+    var err = util.PluginError('test', 'it broke');
+    err.should.be.an.instanceOf(util.PluginError).and.an.instanceOf(Error);
+  });
 });

--- a/test/PluginError.js
+++ b/test/PluginError.js
@@ -191,7 +191,11 @@ describe('PluginError()', function(){
   });
   
   it('should work without new', function () {
-    var err = util.PluginError('test', 'it broke');
-    err.should.be.an.instanceOf(util.PluginError).and.an.instanceOf(Error);
+    var err1 = util.PluginError('test', 'it broke');
+    var err2 = new util.PluginError('test', 'it broke');
+    
+    err1.should.be.an.instanceOf(util.PluginError);
+    err1.should.be.an.instanceOf(Error);
+    err1.should.eql(err2);
   });
 });


### PR DESCRIPTION
This also falls in line with the builtin Error types and most of the other builtins as well.