### PR TITLE
Update template.js

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -13,7 +13,7 @@ module.exports = function(tmpl, data){
   var fn = template(tmpl, forcedSettings);
 
   var wrapped = function(o) {
-    if (typeof o === 'undefined' || typeof o.file === 'undefined') throw new Error('Failed to provide the current file as "file" to the template');
+    if (typeof o === 'undefined') throw new Error('You must provide an Object containing the keys for the template string.');
     return fn(o);
   };
 


### PR DESCRIPTION
It doesn't seem fair to **force** the user to use a `file` attribute on their `Object`, even if `file` isn't defined on the template.

It would also be beneficial to check `lodash`'s implementation of template to see if they deal with the validation of the `Object` parameter passed in. Rather than simply stating `if (typeof o === 'undefined')`. If not maybe use something like `_.isPlainObject` and return in case the function `wrapped` does not receive an `Object` (POJO).

Right now, if you pass an `Array` or anything else that isn't `undefined` (say `[1, 2, 3]` or just `2`) a `ReferenceError` will occur.

See https://github.com/gulpjs/gulp-util/issues/82