### PR TITLE
Add a describe method to the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Information
 
 <table>
-<tr> 
+<tr>
 <td>Package</td><td>gulp-util</td>
 </tr>
 <tr>
@@ -103,9 +103,24 @@ Callback is optional and receives two arguments: error and data
 ```javascript
 gulp.src('stuff/*.js')
   .pipe(gutil.buffer(function(err, files) {
-  
+
   }));
 ```
+
+## describe(description, taskFn)
+
+Adds a `.description` property to a task function, and return that function.
+
+This is useful to add descriptions to tasks that will be presented in the CLI using the `--tasks` option.
+
+```javascript
+var d = gutil.describe;
+
+gulp.task('build', d('build a standalone lib.js file using browserify', function() {
+
+}));
+```
+
 
 ## new PluginError(pluginName, message[, options])
 

--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ module.exports = {
   linefeed: '\n',
   combine: require('./lib/combine'),
   buffer: require('./lib/buffer'),
-  PluginError: require('./lib/PluginError')
+  PluginError: require('./lib/PluginError'),
+  describe: require('./lib/describe')
 };

--- a/lib/describe.js
+++ b/lib/describe.js
@@ -1,0 +1,6 @@
+// Add a description to a task function
+// useful for the --tasks option
+module.exports = function describe ( description, fn ) {
+  fn.description = description;
+  return fn;
+};

--- a/test/describe.js
+++ b/test/describe.js
@@ -1,0 +1,11 @@
+var util = require('..');
+require('should');
+require('mocha');
+
+describe('describe', function(){
+  it('should add a description to a function and return it', function(done){
+	var fn = function () {};
+    util.describe('full description', fn).description.should.equal('full description');
+    done();
+  });
+});


### PR DESCRIPTION
The `--tasks` option of the CLI will soon be able to display meaningful description for tasks (see [gulp/gulp-cli/issues/19](https://github.com/gulpjs/gulp-cli/issues/19)). This very simple method makes it easier to add those descriptions.

```javascript
var d = gutil.describe;

gulp.task('build', d('build a standalone lib.js file using browserify', function() {

}));
```