### PR TITLE
Fixes log formatting and tests logging

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -3,8 +3,7 @@ var dateformat = require('dateformat');
 
 module.exports = function(){
   var time = '['+chalk.grey(dateformat(new Date(), 'HH:MM:ss'))+']';
-  var args = Array.prototype.slice.call(arguments);
-  args.unshift(time);
-  console.log.apply(console, args);
+  process.stdout.write(time + ' ');
+  console.log.apply(console, arguments);
   return this;
 };

--- a/test/log.js
+++ b/test/log.js
@@ -19,7 +19,7 @@ describe('log()', function(){
 
     util.log(1, 2, 3, 4, 'five');
     var time = util.date(new Date(), 'HH:MM:ss');
-    writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 2 3 4 five\n');
+    writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 2 3 4 \'five\'\n');
 
     done();
   });
@@ -39,9 +39,10 @@ describe('log()', function(){
     };
 
     util.log('%s %d %j', 'something', 0.1, {key: 'value'});
-    var time = util.colors.grey(util.date(new Date(), 'HH:MM:ss'));
+    var time = util.date(new Date(), 'HH:MM:ss');
     writtenValue.should.eql(
-      '[' + time + '] something 0.1 {\"key\": \"value\"}\n'
+      '[' + util.colors.grey(time) + '] '+
+      'something 0.1 {\"key\":\"value\"}\n'
     );
 
     done();

--- a/test/log.js
+++ b/test/log.js
@@ -4,30 +4,38 @@ require('mocha');
 
 describe('log()', function(){
   it('should work i guess', function(done){
-    var writtenValue;
+    var count = 0;
+    var writtenValue = '';
 
     // Stub process.stdout.write
     var stdout_write = process.stdout.write;
     process.stdout.write = function(value) {
-      writtenValue = value;
+      writtenValue += value;
+      if(++count > 2){
+        // Restore process.stdout.write after test
+        process.stdout.write = stdout_write;
+      }
     };
 
     util.log(1, 2, 3, 4, 'five');
     var time = util.date(new Date(), 'HH:MM:ss');
     writtenValue.should.eql('[' + util.colors.grey(time) + '] 1 2 3 4 five\n');
 
-    // Restore process.stdout.write
-    process.stdout.write = stdout_write;
     done();
   });
 
   it('should accept formatting', function(done){
-    var writtenValue;
+    var count = 0;
+    var writtenValue = '';
 
     // Stub process.stdout.write
     var stdout_write = process.stdout.write;
     process.stdout.write = function(value) {
-      writtenValue = value;
+      writtenValue += value;
+      if(++count > 2){
+        // Restore process.stdout.write after test
+        process.stdout.write = stdout_write;
+      }
     };
 
     util.log('%s %d %j', 'something', 0.1, {key: 'value'});
@@ -36,8 +44,6 @@ describe('log()', function(){
       '[' + time + '] something 0.1 {\"key\": \"value\"}\n'
     );
 
-    // Restore process.stdout.write
-    process.stdout.write = stdout_write;
     done();
   });
 });

--- a/test/log.js
+++ b/test/log.js
@@ -20,4 +20,24 @@ describe('log()', function(){
     process.stdout.write = stdout_write;
     done();
   });
+
+  it('should accept formatting', function(done){
+    var writtenValue;
+
+    // Stub process.stdout.write
+    var stdout_write = process.stdout.write;
+    process.stdout.write = function(value) {
+      writtenValue = value;
+    };
+
+    util.log('%s %d %j', 'something', 0.1, {key: 'value'});
+    var time = util.colors.grey(util.date(new Date(), 'HH:MM:ss'));
+    writtenValue.should.eql(
+      '[' + time + '] something 0.1 {\"key\": \"value\"}\n'
+    );
+
+    // Restore process.stdout.write
+    process.stdout.write = stdout_write;
+    done();
+  });
 });


### PR DESCRIPTION
Since the first argument of `gutil.log` was the date passing arguments to `console.log` missed formatting if one tried to do so. Added test for it and restored `process.stdout.write` right after the log tests are done so mocha can print something after them.