### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,5 @@
   "engines": {
     "node": ">=0.10"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/wearefractal/gulp-util/raw/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/