### PR TITLE
Removed beep(); from examples of usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 var gutil = require('gulp-util');
 
 gutil.log('stuff happened', 'Really it did', gutil.colors.magenta('123'));
-gutil.beep();
 
 gutil.replaceExtension('file.coffee', '.js'); // file.js
 


### PR DESCRIPTION
gutil.**beep()** has been removed from *gulp-util*. So it should be removed from examples of usage in README file too.