### PR TITLE
add deprecations

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,113 @@
-module.exports = {
-  File: require('vinyl'),
-  replaceExtension: require('replace-ext'),
-  colors: require('chalk'),
-  date: require('dateformat'),
+var deprecated = require('deprecated');
+
+var gutil = {
   log: require('./lib/log'),
-  template: require('./lib/template'),
-  env: require('./lib/env'),
-  beep: require('beeper'),
-  noop: require('./lib/noop'),
-  isStream: require('./lib/isStream'),
-  isBuffer: require('./lib/isBuffer'),
-  isNull: require('./lib/isNull'),
-  linefeed: '\n',
-  combine: require('./lib/combine'),
   buffer: require('./lib/buffer'),
   PluginError: require('./lib/PluginError')
 };
+
+deprecated.field('gutil.File() has been deprecated. ' +
+  'Use the `vinyl` module directly.',
+  console.warn,
+  gutil,
+  'File',
+  require('vinyl')
+);
+
+deprecated.field('gutil.replaceExtension() has been deprecated. ' +
+  'Set the `extname` property of vinyl objects instead.',
+  console.warn,
+  gutil,
+  'replaceExtension',
+  require('replace-ext')
+);
+
+deprecated.field('gutil.colors has been deprecated. ' +
+  'Use the `chalk` module directly.',
+  console.warn,
+  gutil,
+  'colors',
+  require('chalk')
+);
+
+deprecated.field('gutil.date() has been deprecated. ' +
+  'Use the `dateformat` module directly.',
+  console.warn,
+  gutil,
+  'date',
+  require('dateformat')
+);
+
+deprecated.field('gutil.template() has been deprecated. ' +
+  'Use the `lodash.template` module directly.',
+  console.warn,
+  gutil,
+  'template',
+  require('./lib/template')
+);
+
+deprecated.field('gutil.beep() has been deprecated. ' +
+  'Use the `beeper` module directly.',
+  console.warn,
+  gutil,
+  'beep',
+  require('beeper')
+);
+
+deprecated.field('gutil.env has been deprecated. ' +
+  'Use the `minimist` module directly.',
+  console.warn,
+  gutil,
+  'env',
+  require('./lib/env')
+);
+
+deprecated.field('gutil.noop() has been deprecated. ' +
+  'Use the `through2` module directly with the `through.obj()` method',
+  console.warn,
+  gutil,
+  'noop',
+  require('./lib/noop')
+);
+
+deprecated.field('gutil.isStream() has been deprecated. ' +
+  'Use the `isStream()` method of vinyl objects instead.',
+  console.warn,
+  gutil,
+  'isStream',
+  require('./lib/isStream')
+);
+
+deprecated.field('gutil.isBuffer() has been deprecated. ' +
+  'Use the `isBuffer()` method of vinyl objects instead.',
+  console.warn,
+  gutil,
+  'isBuffer',
+  require('./lib/isBuffer')
+);
+
+deprecated.field('gutil.isNull() has been deprecated. ' +
+  'Use the `isNull()` method of vinyl objects instead.',
+  console.warn,
+  gutil,
+  'isNull',
+  require('./lib/isNull')
+);
+
+deprecated.field('gutil.linefeed has been deprecated. ' +
+  'Use the string `\n` instead.',
+  console.warn,
+  gutil,
+  'linefeed',
+  '\n'
+);
+
+deprecated.field('gutil.combine() has been deprecated. ' +
+  'Use the `multipipe` module directly.',
+  console.warn,
+  gutil,
+  'combine',
+  require('./lib/combine')
+);
+
+module.exports = gutil;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "beeper": "^1.0.0",
     "chalk": "^1.0.0",
     "dateformat": "^1.0.11",
+    "deprecated": "0.0.1",
     "lodash._reescape": "^3.0.0",
     "lodash._reevaluate": "^3.0.0",
     "lodash._reinterpolate": "^3.0.0",


### PR DESCRIPTION
## Don't Merge Yet

Ref https://github.com/gulpjs/gulp/issues/360

Properties to deprecate:
- [x] `File`
- [x] `replaceExtension`
- [x] `colors`
- [x] `date`
- [ ] `log`
- [x] `template`
- [x] `env`
- [x] `beep`
- [x] `noop`
- [x] `isStream`
- [x] `isBuffer`
- [x] `isNull`
- [x] `linefeed`
- [x] `combine`
- [ ] `buffer`
- [ ] `PluginError`

Does anyone know of a stream buffering module?

@contra @shinnn where do we stand on PluginError/BetterError?

Logging needs to be completed and back ported to gulp-util before deprecation.
