### PR TITLE
downgrade vinyl dependency to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "object-assign": "^3.0.0",
     "replace-ext": "0.0.1",
     "through2": "^2.0.0",
-    "vinyl": "^0.5.0"
+    "vinyl": "^0.4.0"
   },
   "devDependencies": {
     "buffer-equal": "^0.0.1",


### PR DESCRIPTION
As I mentioned in a comment on 64325ae, the current version of gulp depends on a different version of vinyl-fs (and thus vinyl) than the version gulp-util 3.0.6 depends on. A given version of gulp and gulp-util should share the same underlying version of vinyl-fs/vinyl, surely?