### PR TITLE
Update log to force PluginError toString()

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,14 +1,24 @@
 var hasGulplog = require('has-gulplog');
 
 module.exports = function(){
+  var args;
+  if(arguments) {
+    var PluginError = require('./PluginError');
+    args = Array.prototype.slice.call(arguments);
+    args.forEach(function(currentValue, index, array) {
+      if(currentValue.constructor === PluginError) {
+        array[index] = currentValue.toString();
+      }
+    });
+  }
   if(hasGulplog()){
     // specifically deferring loading here to keep from registering it globally
     var gulplog = require('gulplog');
-    gulplog.info.apply(gulplog, arguments);
+    gulplog.info.apply(gulplog, args);
   } else {
     // specifically defering loading because it might not be used
     var fancylog = require('fancy-log');
-    fancylog.apply(null, arguments);
+    fancylog.apply(null, args);
   }
   return this;
 };

--- a/test/log.js
+++ b/test/log.js
@@ -38,11 +38,12 @@ describe('log()', function(){
       }
     };
 
-    util.log('%s %d %j', 'something', 0.1, {key: 'value'});
+    var pluginError = new util.PluginError('plugin error', new Error('an error'), {showStack: true});
+    util.log('%s %d %j', 'something', 0.1, {key: 'value'}, pluginError);
     var time = util.date(new Date(), 'HH:MM:ss');
     writtenValue.should.eql(
       '[' + util.colors.grey(time) + '] '+
-      'something 0.1 {\"key\":\"value\"}\n'
+      'something 0.1 {\"key\":\"value\"} ' + pluginError.toString() + '\n'
     );
 
     done();


### PR DESCRIPTION
`PluginError` objects were not formatted to string when piped to gutil.log, it needed additional manipulation in order to print the information nicely:

```javascript
var $ = require('gulp-load-plugins')();
var errorHandler = function (error) {
  $.util.log(error.toString());
}
...
.pipe(utilUsingPluginError()).on('error', errorHandler);
```

This affected a number of gulp plugins, causing developers to call `toString()` when returning the error.

The cause is expected behavior by the output. When printing an argument that is not concatenated with the string, the node engine will attempt to print the full object instead of invoking its `toString` implementation.

### Reference
* contra/gulp-coffee#61