### PR TITLE
Deprecation warning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# gulp-util [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status][depstat-image]][depstat-url]
+# gulp-util [![deprecated][deprecated-image]][deprecated-url] [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Coveralls Status][coveralls-image]][coveralls-url] [![Dependency Status][depstat-image]][depstat-url]
 
 ## Information
+
+**DEPRECATION WARNING** : gulp-util is being [outdated][deprecated-url], please, rely on [vinyl module](https://www.npmjs.com/package/vinyl) directly.
 
 <table>
 <tr> 
@@ -144,3 +146,5 @@ var err = new gutil.PluginError('test', existingError, {showStack: true});
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/gulp-util.svg
 [depstat-url]: https://david-dm.org/gulpjs/gulp-util
 [depstat-image]: https://david-dm.org/gulpjs/gulp-util.svg
+[deprecated-url]: https://github.com/gulpjs/gulp-util/issues/118#issuecomment-204107094
+[deprecated-image]: https://img.shields.io/badge/status-deprecated-red.svg


### PR DESCRIPTION
Lets make explicit warning "package is outdated" on the main pages of package:

1. on GitHub
2. on NPM

## Reason

Let's try to run:

```bash
$ npm outdated --depth=5
```

on any project, which uses GULP. Sample output:

```
object-assign                3.0.0         3.0.0         4.0.1  tndr > sequelize-cli > gulp > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-jshint > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-csslint > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-less > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-csso > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-zip > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-size > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-csslint-report > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-notify > gulp-util
object-assign                3.0.0         3.0.0         4.0.1  tndr > gulp-uglify > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-csso > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-zip > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-notify > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > sequelize-cli > gulp > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-csslint-report > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-less > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-uglify > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-size > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-jshint > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-csslint > gulp-util
vinyl                        0.5.3         0.5.3         1.1.1  tndr > gulp-autoprefixer > gulp-util
```

As you could see, there are a lot of gulp-plugins, which still use **gulp-util**