### PR TITLE
Add LazyTask loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 *.node
 components
 coverage
+.idea/

--- a/README.md
+++ b/README.md
@@ -136,6 +136,39 @@ var existingError = new Error('OMG');
 var err = new gutil.PluginError('test', existingError, {showStack: true});
 ```
 
+## lazyTask(gulp [, taskPathBuilderFunctionOrBasePath])
+
+This function helps you load only needable tasks in this session.
+Tasks compile more quickly and only usable.
+
+`taskPathBuilderFunctionOrBasePath` - string or callback for build path to the loading module. If it specified as `string` It will recognized as base path for loading modules
+
+```javascript
+var task = lazyTask(gulp, path.join(__dirname, '/some/path/to/tasks'));
+
+gulp.task('baz', [
+    task('my-awesome-task-module'),
+    task('another/task-module')
+])
+
+gulp.task('foo', [
+    task('bar/sometask'), // .../some/path/to/tasks/bar/sometask.js OR .../some/path/to/tasks/bar/sometask/index.js
+    task('/somedir/bar') // load /somedir/bar.js OR /somedir/bar/index.js
+])
+```
+
+```javascript
+// example of task module
+module.exports = function (callback) {
+    return gulp.src('**/*')
+        .pipe(/*...*/);
+};
+```
+
+If you execute `gulp foo` you will load only `bar/sometask` & `/somedir/bar` without `my-awesome-task-module` & `another/task-module`
+
+You still use direct call of lazytasks, for example `gulp bar/sometask`
+
 [npm-url]: https://www.npmjs.com/package/gulp-util
 [npm-image]: https://badge.fury.io/js/gulp-util.svg
 [travis-url]: https://travis-ci.org/gulpjs/gulp-util

--- a/index.js
+++ b/index.js
@@ -14,5 +14,6 @@ module.exports = {
   linefeed: '\n',
   combine: require('./lib/combine'),
   buffer: require('./lib/buffer'),
-  PluginError: require('./lib/PluginError')
+  PluginError: require('./lib/PluginError'),
+  lazyTask: require('./lib/lazyTask')
 };

--- a/lib/lazyTask.js
+++ b/lib/lazyTask.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = function (gulp, taskPathBuilder) {
+    var collection = {};
+
+    if (!taskPathBuilder) {
+        taskPathBuilder = function (taskName) {
+            return path.resolve(process.cwd(), taskName);
+        };
+    }
+
+    if (typeof taskPathBuilder === 'string') {
+        var baseName = taskPathBuilder;
+
+        taskPathBuilder = function (taskName) {
+            return path.resolve(baseName, taskName);
+        };
+    }
+
+    return function (taskName) {
+        var taskPath = taskPathBuilder(taskName);
+
+        if (collection.hasOwnProperty(taskName)) {
+            return taskName;
+        }
+
+        collection[taskName] = true;
+
+        gulp.task(taskName, function (callback) {
+            var task = require(taskPath);
+
+            return task(callback);
+        });
+
+        return taskName;
+    };
+};


### PR DESCRIPTION
It is most popular solution for splitting monolithic gulpfile and lazy loading of modules. 
I think all developers made it by themselves

I didn't cover tests this function because there is some problem with loading files by `require` function and test it. But if it has important for this project I can create in test-runtime jsfile for test loading 