### PR TITLE
updated deps: lodash.template, multipipe, object-assign, replace-ext, vinyl

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "lodash._reescape": "^3.0.0",
     "lodash._reevaluate": "^3.0.0",
     "lodash._reinterpolate": "^3.0.0",
-    "lodash.template": "^3.0.0",
+    "lodash.template": "^4.4.0",
     "minimist": "^1.1.0",
-    "multipipe": "^0.1.2",
-    "object-assign": "^3.0.0",
-    "replace-ext": "0.0.1",
+    "multipipe": "^1.0.2",
+    "object-assign": "^4.1.0",
+    "replace-ext": "1.0.0",
     "through2": "^2.0.0",
-    "vinyl": "^0.5.0"
+    "vinyl": "^2.0.0"
   },
   "devDependencies": {
     "buffer-equal": "^0.0.1",

--- a/test/File.js
+++ b/test/File.js
@@ -6,7 +6,7 @@ require('mocha');
 describe('File()', function() {
   it('should return a valid file', function(done) {
     var fname = path.join(__dirname, './fixtures/test.coffee');
-    var base = path.join(__dirname, './fixtures/');
+    var base = path.join(__dirname, './fixtures');
     var file = new util.File({
       base: base,
       cwd: __dirname,


### PR DESCRIPTION
note that an update to array-differ ^2.0.0 is not possible unless one wants to give up supporting node < 6.
one test case had to be adjusted to fit to the vinyl update (as of version 2.0.0, vinyl automatically removes trailing separators of directories).