### PR TITLE
Provided correct repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gulp-util",
   "description": "Utility functions for gulp plugins",
   "version": "3.0.8",
-  "repository": "gulpjs/gulp-util",
+  "repository": "https://github.com/gulpjs/gulp-util.git",
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "files": [
     "index.js",


### PR DESCRIPTION
I have noticed that package.json is missing correct git repository URL, as a result, the package is invalid according to [package.json validator](http://package-json-validator.com/). Therefore, I have updated the link with the following information: "https://github.com/gulpjs/gulp-util.git".