### PR TITLE
Fix for issue #140

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "object-assign": "^3.0.0",
     "replace-ext": "0.0.1",
     "through2": "^2.0.0",
-    "vinyl": "^0.5.0"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "buffer-equal": "^0.0.1",

--- a/test/File.js
+++ b/test/File.js
@@ -6,7 +6,7 @@ require('mocha');
 describe('File()', function() {
   it('should return a valid file', function(done) {
     var fname = path.join(__dirname, './fixtures/test.coffee');
-    var base = path.join(__dirname, './fixtures/');
+    var base = path.join(__dirname, './fixtures');
     var file = new util.File({
       base: base,
       cwd: __dirname,


### PR DESCRIPTION
Some gulp plugins, amongst which gulp-util, are including a very old version of vinyl. This causes problems with differently-shaped vinyl objects going through the gulp pipelines. Please update your vinyl dependency